### PR TITLE
Cherrypicked from 4.17 mainline: kbuild: replace hardcoded bison in cmd_bison_h with $(YACC)

### DIFF
--- a/scripts/Makefile.lib
+++ b/scripts/Makefile.lib
@@ -228,7 +228,7 @@ $(filter %.tab.c,$(targets)): $(obj)/%.tab.c: $(src)/%.y FORCE
 	$(call if_changed,bison)
 
 quiet_cmd_bison_h = YACC    $@
-      cmd_bison_h = bison -o/dev/null --defines=$@ -t -l -p $(YACC_PREFIX) $<
+      cmd_bison_h = $(YACC) -o/dev/null --defines=$@ -t -l -p $(YACC_PREFIX) $<
 
 ifdef REGENERATE_PARSERS
 .PRECIOUS: $(src)/%.tab.h_shipped


### PR DESCRIPTION
This fixes build error due to bison from PATH being used.